### PR TITLE
OCM 1.1 invitation work flow

### DIFF
--- a/apps/cloud_federation_api/appinfo/routes.php
+++ b/apps/cloud_federation_api/appinfo/routes.php
@@ -20,11 +20,11 @@ return [
 			'verb' => 'POST',
 			'root' => '/ocm',
 		],
-		//		[
-		//			'name' => 'RequestHandler#inviteAccepted',
-		//			'url' => '/invite-accepted',
-		//			'verb' => 'POST',
-		//			'root' => '/ocm',
-		//		]
+		[
+			'name' => 'RequestHandler#inviteAccepted',
+			'url' => '/invite-accepted',
+			'verb' => 'POST',
+			'root' => '/ocm',
+		]
 	],
 ];

--- a/apps/cloud_federation_api/lib/Capabilities.php
+++ b/apps/cloud_federation_api/lib/Capabilities.php
@@ -19,7 +19,7 @@ use OCP\OCM\IOCMProvider;
 use Psr\Log\LoggerInterface;
 
 class Capabilities implements ICapability {
-	public const API_VERSION = '1.1'; // informative, real version.
+	public const API_VERSION = '1.1.0';
 
 	public function __construct(
 		private IURLGenerator $urlGenerator,
@@ -42,13 +42,16 @@ class Capabilities implements ICapability {
 	 *             keyId: string,
 	 *             publicKeyPem: string,
 	 *         },
+	 *         provider: string,
 	 *         resourceTypes: list<array{
 	 *             name: string,
 	 *             shareTypes: list<string>,
 	 *             protocols: array<string, string>
 	 *         }>,
 	 *         version: string
-	 *     }
+	 *         capabilities: array{
+	 *             string,
+	 *         }
 	 * }
 	 * @throws OCMArgumentException
 	 */
@@ -57,6 +60,7 @@ class Capabilities implements ICapability {
 
 		$this->provider->setEnabled(true);
 		$this->provider->setApiVersion(self::API_VERSION);
+		$this->provider->setCapabilities(['/invite-accepted', '/notifications', '/shares']);
 
 		$pos = strrpos($url, '/');
 		if ($pos === false) {

--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -17,6 +17,7 @@ use OC\OCM\OCMSignatoryManager;
 use OCA\CloudFederationAPI\Config;
 use OCA\CloudFederationAPI\ResponseDefinitions;
 use OCA\FederatedFileSharing\AddressHandler;
+use OCA\Federation\TrustedServers;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\BruteForceProtection;
@@ -33,6 +34,7 @@ use OCP\Federation\ICloudFederationFactory;
 use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Federation\ICloudIdManager;
 use OCP\IAppConfig;
+use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -67,6 +69,8 @@ class RequestHandlerController extends Controller {
 		private ICloudIdManager $cloudIdManager,
 		private readonly ISignatureManager $signatureManager,
 		private readonly OCMSignatoryManager $signatoryManager,
+		private IConfig $ocConfig,
+		private TrustedServers $trustedServers
 	) {
 		parent::__construct($appName, $request);
 	}

--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -218,6 +218,73 @@ class RequestHandlerController extends Controller {
 	}
 
 	/**
+	 * Inform the sender that an invitation was accepted to start sharing
+	 *
+	 * Inform about an accepted invitation so the user on the sender provider's side
+	 * can initiate the OCM share creation. To protect the identity of the parties,
+	 * for shares created following an OCM invitation, the user id MAY be hashed,
+	 * and recipients implementing the OCM invitation workflow MAY refuse to process
+	 * shares coming from unknown parties.
+	 *
+	 * @param string $recipientProvider
+	 * @param string $token
+	 * @param string $userId
+	 * @param string $email
+	 * @param string $name
+	 * @return JSONResponse
+	 * 200: invitation accepted
+	 * 400: Invalid token
+	 * 403: Invitation token does not exist
+	 * 409: User is allready known by the OCM provider
+	 * spec link: https://cs3org.github.io/OCM-API/docs.html?branch=v1.1.0&repo=OCM-API&user=cs3org#/paths/~1invite-accepted/post
+	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
+	#[BruteForceProtection(action: 'inviteAccepted')]
+	public function inviteAccepted(string $recipientProvider, string $token, string $userId, string $email, string $name): JSONResponse {
+		$this->logger->debug('Invite accepted for ' . $userId . ' with token ' . $token . ' and email ' . $email . ' and name ' . $name);
+		$found_for_this_user = false;
+		foreach ($this->ocConfig->getAppKeys($this->appName) as $key) {
+			if(str_starts_with($key, $token) ){
+				$found_for_this_user = $this->getAppValue($this->appName, $token . '_remote_id') === $userId;
+			}
+		}
+
+
+
+		if (!$found_for_this_user) {
+			$response = ['message' => 'Invalid or non existing token', 'error' => true];
+			$status = Http::STATUS_BAD_REQUEST;
+			return new JSONResponse($response,$status);
+		}
+
+		if(!$this->trustedServers->isTrustedServer($recipientProvider)) {
+			$response = ['message' => 'Remote server not trusted', 'error' => true];
+			$status = Http::STATUS_FORBIDDEN;
+			return new JSONResponse($response,$status);
+		}
+		// Note: Not implementing 404 Invitation token does not exist, instead using 400
+
+		if ($this->ocConfig->getAppValue($this->appName, $token . '_accepted') === true ) {
+			$response = ['message' => 'Invite already accepted', 'error' => true];
+			$status = Http::STATUS_CONFLICT;
+			return new JSONResponse($response,$status);
+		}
+
+
+		$localId = $this->ocConfig->getAppValue($this->appName, $token . '_local_id');
+		$response = ['usedID' => $localId, 'email' => $email, 'name' => $name];
+		$status = Http::STATUS_OK;
+		$this->ocConfig->setAppValue($this->appName, $token . '_accepted', true);
+		//  TODO: Set these values where the invitation workflow is implemented
+		//  $this->ocConfig->setAppValue($this->appName, $token . '_accepted', false);
+		//	$this->ocConfig->setAppValue($this->appName, $token . '_local_id', $localId);
+		//	$this->ocConfig->setAppValue($this->appName, $token . '_remote_id', $remoteId);
+
+		return new JSONResponse($response,$status);
+	}
+
+	/**
 	 * Send a notification about an existing share
 	 *
 	 * @param string $notificationType Notification type, e.g. SHARE_ACCEPTED

--- a/apps/cloud_federation_api/lib/Migration/Version0001Date202502262004.php
+++ b/apps/cloud_federation_api/lib/Migration/Version0001Date202502262004.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\CloudFederationAPI\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version0001Date202502262004 extends SimpleMigrationStep
+{
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options)
+	{
+		/** @var ISchemaWrapper $schema */
+
+
+		$schema = $schemaClosure();
+		$table_name = 'federated_invites';
+
+		if (! $schema->hasTable($table_name)) {
+
+			$table = $schema->createTable($table_name);
+			$table->addColumn('id', 'bigint', [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 20,
+				'unsigned' => true,
+			]);
+
+			$table->addColumn('user_id', 'bigint', [
+				'notnull' => false,
+				'length' => 20,
+				'unsigned' => true,
+
+			]);
+
+
+			$table->addColumn('token', 'string', [
+				'notnull' => true,
+				'length' => 60,
+			]);
+			$table->addColumn('email', 'string', [
+				'notnull' => true,
+				'length' => 256,
+			]);
+			$table->addColumn('accepted', 'boolean', [
+				'notnull' => false,
+				'default' => false
+			]);
+			$table->addColumn('createdAt', 'datetime', [
+				'notnull' => true,
+			]);
+
+			$table->addColumn('expiredAt', 'datetime', [
+				'notnull' => false,
+			]);
+
+			$table->addColumn('acceptedAt', 'datetime', [
+				'notnull' => false,
+			]);
+
+
+			$table->setPrimaryKey(['id']);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -16,13 +16,17 @@ use OCP\OCM\Exceptions\OCMArgumentException;
 use OCP\OCM\Exceptions\OCMProviderException;
 use OCP\OCM\IOCMProvider;
 use OCP\OCM\IOCMResource;
+use OCP\IConfig;
 
 /**
  * @since 28.0.0
  */
 class OCMProvider implements IOCMProvider {
+	private IConfig $config;
+	private string $provider;
 	private bool $enabled = false;
 	private string $apiVersion = '';
+	private array $capabilities = [];
 	private string $endPoint = '';
 	/** @var IOCMResource[] */
 	private array $resourceTypes = [];
@@ -31,7 +35,11 @@ class OCMProvider implements IOCMProvider {
 
 	public function __construct(
 		protected IEventDispatcher $dispatcher,
+		IConfig $config,
+		LoggerInterface $logger
 	) {
+		$this->config = $config;
+		$this->provider = 'Nextcloud ' . $config->getSystemValue('version');
 	}
 
 	/**
@@ -88,6 +96,34 @@ class OCMProvider implements IOCMProvider {
 		return $this->endPoint;
 	}
 
+	/**
+	 * @return string
+	 */
+	public function getProvider(): string {
+		return $this->provider;
+	}
+
+	/**
+	 * @param array $capabilities
+	 *
+	 * @return this
+	 */
+	public function setCapabilities(array $capabilities): static {
+		foreach ($capabilities as $key => $value) {
+			if (!in_array($value, $this->capabilities)) {
+				array_push($this->capabilities, $value);
+			}
+		}
+
+		return $this;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getCapabilities(): array {
+		return $this->capabilities;
+	}
 	/**
 	 * create a new resource to later add it with {@see IOCMProvider::addResourceType()}
 	 * @return IOCMResource
@@ -237,7 +273,9 @@ class OCMProvider implements IOCMProvider {
 			'version' => $this->getApiVersion(), // informative but real version
 			'endPoint' => $this->getEndPoint(),
 			'publicKey' => $this->getSignatory()->jsonSerialize(),
-			'resourceTypes' => $resourceTypes
+			'resourceTypes' => $resourceTypes,
+			'provider' => $this->getProvider(),
+			'capabilities' => $this->getCapabilities(),
 		];
 	}
 }

--- a/lib/public/OCM/IOCMProvider.php
+++ b/lib/public/OCM/IOCMProvider.php
@@ -55,6 +55,25 @@ interface IOCMProvider extends JsonSerializable {
 	public function getApiVersion(): string;
 
 	/**
+	 * returns the capabilities of the API
+	 *
+	 * @return array
+	 * @since 30.0.0
+	 */
+	public function getCapabilities(): array;
+
+	/**
+	 * set the capabilities of the API
+	 *
+	 * @param array $capabilities
+	 *
+	 * @return $this
+	 * @since 30.0.0
+	 */
+
+	public function setCapabilities(array $capabilities): static;
+
+	/**
 	 * configure endpoint
 	 *
 	 * @param string $endPoint
@@ -72,6 +91,13 @@ interface IOCMProvider extends JsonSerializable {
 	 */
 	public function getEndPoint(): string;
 
+	/**
+	 * get provider
+	 *
+	 * @return string
+	 * @since 30.0.0
+	 */
+	public function getProvider()): string;
 	/**
 	 * create a new resource to later add it with {@see addResourceType()}
 	 * @return IOCMResource


### PR DESCRIPTION
## Summary
This patchset adds support for OCM 1.1 invitation workflow.

It adds the invite-accepted enpoint: https://cs3org.github.io/OCM-API/docs.html?branch=v1.1.0&repo=OCM-API&user=cs3org#/paths/~1invite-accepted/post

and also the database table to hold invites: federated_invites.

An upcoming pr to contacts app will implement ui for sending and accepting invites.